### PR TITLE
Update role for tezos_network URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 # defaults file for roles/tezos_node
 
-tezos_docker_image: tezos/tezos:v8.2
+tezos_docker_image: tezos/tezos:v9.0
+deployment_name: "{{ tezos_network }}"
 
-node_data_dir: "/srv/tezos/{{ tezos_network }}_node"
-client_data_dir: "/srv/tezos/{{ tezos_network }}_client"
+node_data_dir: "/srv/tezos/{{ deployment_name }}_node"
+client_data_dir: "/srv/tezos/{{ deployment_name }}_client"
 
 # The port that docker maps externally
 RPC_PORT: 8732
@@ -13,7 +14,7 @@ P2P_PORT: 9732
 RPC_PORT_INTERNAL: 8732
 P2P_PORT_INTERNAL: 9732
 
-node_rpc_url: "http://{{ tezos_network }}_node:{{ RPC_PORT_INTERNAL }}"
+node_rpc_url: "http://{{ deployment_name }}_node:{{ RPC_PORT_INTERNAL }}"
 
 history_mode: full
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,10 @@
 ---
-# defaults file for roles/tezos_node
+# defaults file for roles/tezos_node_envoy_proxy
 
 tezos_docker_image: tezos/tezos:v9.0
-deployment_name: "{{ tezos_network }}"
 
-node_data_dir: "/srv/tezos/{{ deployment_name }}_node"
-client_data_dir: "/srv/tezos/{{ deployment_name }}_client"
+node_data_dir: "/srv/tezos/{{ tezos_network }}_node"
+client_data_dir: "/srv/tezos/{{ tezos_network }}_client"
 
 # The port that docker maps externally
 RPC_PORT: 8732
@@ -13,8 +12,6 @@ P2P_PORT: 9732
 # The port that the Tezos RPC process listens on internally
 RPC_PORT_INTERNAL: 8732
 P2P_PORT_INTERNAL: 9732
-
-node_rpc_url: "http://{{ deployment_name }}_node:{{ RPC_PORT_INTERNAL }}"
 
 history_mode: full
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: change tezos_network variable
   set_fact:
     network_name: "{{ tezos_network | regex_search('([^/]*)$') }}"
-  when: '"http" in tezos_network'
+  when: tezos_network is regex("((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*")
 
 - name: change node and client directory names
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,10 +13,6 @@
     node_rpc_url: "{% if node_rpc_url is defined %}{{ node_rpc_url }}{% else %}http://{{ network_name }}_node:{{ RPC_PORT_INTERNAL }}{% endif %}"
   when: network_name is defined
 
-- name: What are the values
-  debug:
-    msg: "The value of node_data_dir is {{ node_data_dir }}"
-
 - name: node data directories
   file:
     dest: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,11 +66,11 @@
 
 - name: create docker network
   docker_network:
-    name: "{{ tezos_network }}"
+    name: "{{ deployment_name }}"
 
 - name: run tezos node
   docker_container:
-    name: "{{ tezos_network }}_node"
+    name: "{{ deployment_name }}_node"
     image: "{{ tezos_docker_image }}"
     restart_policy: always
     volumes:
@@ -80,7 +80,7 @@
       - "{{ RPC_PORT }}:{{ RPC_PORT_INTERNAL }}"
       - "{{ P2P_PORT }}:{{ P2P_PORT_INTERNAL }}"
     networks:
-      - name: "{{ tezos_network }}"
+      - name: "{{ deployment_name }}"
     entrypoint: >
       tezos-node
       run
@@ -117,4 +117,4 @@
       --endpoint {{ node_rpc_url }}
       config init
     networks:
-      - name: "{{ tezos_network }}"
+      - name: "{{ deployment_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,21 @@
 ---
-# tasks file for roles/tezos_node
+# tasks file for roles/tezos_node_envoy_proxy
+
+- name: change tezos_network variable
+  set_fact:
+    network_name: "{{ tezos_network | regex_search('([^/]*)$') }}"
+  when: '"http" in tezos_network'
+
+- name: change node and client directory names
+  set_fact:
+    node_data_dir: "/srv/tezos/{{ network_name }}_node"
+    client_data_dir: "/srv/tezos/{{ network_name }}_client"
+    node_rpc_url: "{% if node_rpc_url is defined %}{{ node_rpc_url }}{% else %}http://{{ network_name }}_node:{{ RPC_PORT_INTERNAL }}{% endif %}"
+  when: network_name is defined
+
+- name: What are the values
+  debug:
+    msg: "The value of node_data_dir is {{ node_data_dir }}"
 
 - name: node data directories
   file:
@@ -22,7 +38,7 @@
     dest: "{{ node_data_dir }}/config.json"
     owner: "100"
 
-- name: generate tezos-node config "{{ tezos_network }}"
+- name: generate tezos-node config "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
   when:  not has_config.stat.exists and tezos_node_config_template is undefined
   docker_container:
     name: init_tezos_node_config
@@ -66,11 +82,11 @@
 
 - name: create docker network
   docker_network:
-    name: "{{ deployment_name }}"
+    name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
 
 - name: run tezos node
   docker_container:
-    name: "{{ deployment_name }}_node"
+    name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}_node"
     image: "{{ tezos_docker_image }}"
     restart_policy: always
     volumes:
@@ -80,7 +96,7 @@
       - "{{ RPC_PORT }}:{{ RPC_PORT_INTERNAL }}"
       - "{{ P2P_PORT }}:{{ P2P_PORT_INTERNAL }}"
     networks:
-      - name: "{{ deployment_name }}"
+      - name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
     entrypoint: >
       tezos-node
       run
@@ -102,7 +118,7 @@
     path: "{{ client_data_dir }}/config"
   register: has_client_config
 
-- name: generate tezos-client config "{{ tezos_network }}"
+- name: generate tezos-client config "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"
   when:  not has_client_config.stat.exists
   docker_container:
     name: init_tezos_client_config
@@ -117,4 +133,4 @@
       --endpoint {{ node_rpc_url }}
       config init
     networks:
-      - name: "{{ deployment_name }}"
+      - name: "{% if network_name is defined %}{{ network_name }}{% else %}{{ tezos_network }}{% endif %}"


### PR DESCRIPTION
This update will allow the role to take a URL value for the tezos_network variable. If the value of `tezos_network `  is a URL then a new variable is set called `network_name`. The value of `network_name` will be the string after the last `/` in the URL.  This new variable will be used for naming directories, configuring the `node_rpc_url` variable, and naming the docker container. The default value `node_rpc_url` is no longer set in the `defaults.yml` file but is now set in the playbook at runtime. The value of `tezos_network` (In this case a URL) will be used to start the docker container with the `--network` flag.