### PR TITLE
Add tezos metrics to all nodes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ rpc_port_internal: 8732
 p2p_port_internal: 9732
 octez_metrics_port_internal: 9932
 
-tezos_node_additional_parameters: []
+tezos_node_additional_parameters: ["--metrics-addr=0.0.0.0:9932"]
 tezos_node_env_variables: {}
 
 history_mode: full

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,6 @@
         --history-mode "{{ history_mode }}"
         --cors-origin "*"
         --cors-header "Content-Type"
-        --metrics-addr=0.0.0.0:9932
         {{ tezos_node_additional_parameters | join(' ') }}
     env: "{{ tezos_node_env_variables }}"
     volumes_from:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,11 +98,13 @@
         --history-mode "{{ history_mode }}"
         --cors-origin "*"
         --cors-header "Content-Type"
-        {{ tezos_docker_image is match("tezos/tezos:(v13.*|master_.*)") | ternary("--metrics-addr=0.0.0.0:9932", "") }}
+        --metrics-addr=0.0.0.0:9932
         {{ tezos_node_additional_parameters | join(' ') }}
     env: "{{ tezos_node_env_variables }}"
     volumes_from:
       - "{{ network_name }}_node_volumes"
+    comparisons:
+      env: strict
 
 - name: deploy tezos_exporter side car
   docker_container:


### PR DESCRIPTION
Now that all networks are on Octez `v13.0` we can enable metrics on all nodes and remove the metrics condition.