### PR TITLE
Add metrics as default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ rpc_port_internal: 8732
 p2p_port_internal: 9732
 octez_metrics_port_internal: 9932
 
-tezos_node_additional_parameters: ["--metrics-addr=0.0.0.0:9932"]
+tezos_node_additional_parameters: []
 tezos_node_env_variables: {}
 
 history_mode: full

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,6 +98,7 @@
         --history-mode "{{ history_mode }}"
         --cors-origin "*"
         --cors-header "Content-Type"
+        --metrics-addr=0.0.0.0:9932
         {{ tezos_node_additional_parameters | join(' ') }}
     env: "{{ tezos_node_env_variables }}"
     volumes_from:


### PR DESCRIPTION
Re-adding the metrics as default since they show different metrics than our Tezos exporter, so it's useful to have both. We also have a number of playbooks that pass additional variables as well and we'd have to add the metrics flag to all of those as well since the default list of extra vars would be overwritten